### PR TITLE
Fix downloading of payloads for vers < 11.10.x-E

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         function getUrlFromVersion(v)
         {
             //v = (6) ["11", "10", "0", "7", "E", "OLD"]
-            if (v[0] == "11" && v[1] >= "10" && v[4] == "E") {
+            if (v[0] == "11" && v[1] >= 10 && v[4] == "E") {
                 return "https://bruteforcemovable.com/otherapp/"+getFilenameFromVersion(v)+".bin";
             }
             return "http://smealum.github.io/ninjhax2/JL1Xf2KFVm/otherapp/"+getFilenameFromVersion(v)+".bin";
@@ -28,7 +28,7 @@
 
         function getRopbinUrlFromVersion(v)
         {
-            if (v[0] == "11" && v[1] >= "10" && v[4] == "E") {
+            if (v[0] == "11" && v[1] >= 10 && v[4] == "E") {
                 alert("Sorry. We currently do not have a 11." + v[1] + " ropbin for european systems.");
                 return "/3ds";
             }


### PR DESCRIPTION
Currently the site performs an inequality with two strings which results in undesired behavior.
The issue: the comparison `v[1] >= "10"` will only perform the comparison on the first character which in this case will always be true.
This PR corrects that by telling JS to convert the string into an integer before comparing the numbers.

For more information see:
https://www.w3schools.com/js/js_comparisons.asp